### PR TITLE
Improve setting static routes

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,9 @@ _set_static_routes() {
             interface=${ifname}
         fi
         for route in ${STATIC_ROUTES}; do
-            ip route add ${route} dev "${interface}" || true
+            # subshell to reset IFS - otherwise ${route} is not split
+            # by words
+            ( unset IFS; ip route add ${route} dev ${interface} ) || true
         done
     fi 
 }


### PR DESCRIPTION
The current implementation of setting static routes in vxlan-connector
only accepts device routes. If one wants to use a static route such as

    192.168.1.2 via 10.0.0.1 dev vx101

(next hop needs to go through the 'vx101' interface), one needs to use
the environment variable STATIC_ROUTES, set it like "192.168.1.2 via
10.0.0.1" and the _static_routes() function should take care of the
rest. Except that it does not:

    ip route add 192.168.1.2 via 10.0.0.1 dev vx101
    Error: any valid prefix is expected rather than "192.168.1.2 via 10.0.0.1".

This commit addresses the issue by making use of "eval" to get the
formal correct routes to be applied.